### PR TITLE
Proof-of-reserves aToken

### DIFF
--- a/contracts/interfaces/IAPoRToken.sol
+++ b/contracts/interfaces/IAPoRToken.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.6.12;
+
+import {IAToken} from './IAToken.sol';
+
+interface IAPoRToken is IAToken {
+  /**
+   * @notice Event emitted when the feed is updated
+   */
+  event NewFeed(address oldFeed, address newFeed);
+
+  /**
+   * @notice Event emitted when the heartbeat of a feed is updated
+   */
+  event NewHeartbeat(uint256 oldHeartbeat, uint256 newHeartbeat);
+
+  /*** Admin Functions ***/
+
+  function _setFeed(address newFeed) external returns (uint256);
+
+  function _setHeartbeat(uint256 newHeartbeat) external returns (uint256);
+}

--- a/contracts/interfaces/IAPoRToken.sol
+++ b/contracts/interfaces/IAPoRToken.sol
@@ -16,7 +16,7 @@ interface IAPoRToken is IAToken {
 
   /*** Admin Functions ***/
 
-  function _setFeed(address newFeed) external returns (uint256);
+  function setFeed(address newFeed) external returns (uint256);
 
-  function _setHeartbeat(uint256 newHeartbeat) external returns (uint256);
+  function setHeartbeat(uint256 newHeartbeat) external returns (uint256);
 }

--- a/contracts/interfaces/IChainlinkAggregatorV3.sol
+++ b/contracts/interfaces/IChainlinkAggregatorV3.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity >=0.5.0;
+
+interface IChainlinkAggregatorV3 {
+  function decimals() external view returns (uint8);
+
+  function description() external view returns (string memory);
+
+  function version() external view returns (uint256);
+
+  // getRoundData and latestRoundData should both raise "No data present"
+  // if they do not have data to report, instead of returning unset values
+  // which could be misinterpreted as actual reported values.
+  function getRoundData(uint80 _roundId)
+    external
+    view
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    );
+
+  function latestRoundData()
+    external
+    view
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    );
+}

--- a/contracts/mocks/oracle/CLAggregators/MockV3Aggregator.sol
+++ b/contracts/mocks/oracle/CLAggregators/MockV3Aggregator.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.6.12;
+
+import '../../../interfaces/IChainlinkAggregatorV3.sol';
+
+/**
+ * @title MockV3Aggregator
+ * @notice Based on the FluxAggregator contract
+ * @notice Use this contract when you need to test
+ * other contract's ability to read data from an
+ * aggregator contract, but how the aggregator got
+ * its answer is unimportant
+ */
+contract MockV3Aggregator is IChainlinkAggregatorV3 {
+  uint256 public constant override version = 0;
+
+  uint8 public override decimals;
+  int256 public latestAnswer;
+  uint256 public latestTimestamp;
+  uint256 public latestRound;
+
+  mapping(uint256 => int256) public getAnswer;
+  mapping(uint256 => uint256) public getTimestamp;
+  mapping(uint256 => uint256) private getStartedAt;
+
+  constructor(uint8 _decimals, int256 _initialAnswer) public {
+    decimals = _decimals;
+    updateAnswer(_initialAnswer);
+  }
+
+  function updateAnswer(int256 _answer) public {
+    latestAnswer = _answer;
+    latestTimestamp = block.timestamp;
+    latestRound++;
+    getAnswer[latestRound] = _answer;
+    getTimestamp[latestRound] = block.timestamp;
+    getStartedAt[latestRound] = block.timestamp;
+  }
+
+  function updateRoundData(
+    uint80 _roundId,
+    int256 _answer,
+    uint256 _timestamp,
+    uint256 _startedAt
+  ) public {
+    latestRound = _roundId;
+    latestAnswer = _answer;
+    latestTimestamp = _timestamp;
+    getAnswer[latestRound] = _answer;
+    getTimestamp[latestRound] = _timestamp;
+    getStartedAt[latestRound] = _startedAt;
+  }
+
+  function getRoundData(uint80 _roundId)
+    external
+    view
+    override
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    )
+  {
+    return (
+      _roundId,
+      getAnswer[_roundId],
+      getStartedAt[_roundId],
+      getTimestamp[_roundId],
+      _roundId
+    );
+  }
+
+  function latestRoundData()
+    external
+    view
+    override
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    )
+  {
+    return (
+      uint80(latestRound),
+      getAnswer[latestRound],
+      getStartedAt[latestRound],
+      getTimestamp[latestRound],
+      uint80(latestRound)
+    );
+  }
+
+  function description() external view override returns (string memory) {
+    return 'MockV3Aggregator.sol';
+  }
+}

--- a/contracts/protocol/libraries/helpers/Errors.sol
+++ b/contracts/protocol/libraries/helpers/Errors.sol
@@ -103,6 +103,12 @@ library Errors {
   string public constant LP_NOT_CONTRACT = '78';
   string public constant SDT_STABLE_DEBT_OVERFLOW = '79';
   string public constant SDT_BURN_EXCEEDS_BALANCE = '80';
+  string public constant AT_POR_INVALID_ANSWER = '81';
+  string public constant AT_POR_INVALID_TIMESTAMP = '82';
+  string public constant AT_POR_ANSWER_TOO_OLD = '83';
+  string public constant AT_POR_INVALID_DECIMALS = '84';
+  string public constant AT_POR_UNDERLYING_GREATER_THAN_RESERVES = '85';
+  string public constant AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE = '86';
 
   enum CollateralManagerErrors {
     NO_ERROR,

--- a/contracts/protocol/tokenization/APoRToken.sol
+++ b/contracts/protocol/tokenization/APoRToken.sol
@@ -82,7 +82,7 @@ contract APoRToken is AToken, IAPoRToken {
    * @dev Admin function to set a new feed
    * @param newFeed Address of the new feed
    */
-  function _setFeed(address newFeed) external override onlyPoolAdmin returns (uint256) {
+  function setFeed(address newFeed) external override onlyPoolAdmin returns (uint256) {
     emit NewFeed(feed, newFeed);
     feed = newFeed;
   }
@@ -92,7 +92,7 @@ contract APoRToken is AToken, IAPoRToken {
    * @dev Admin function to set the heartbeat
    * @param newHeartbeat Value of the age of the latest update from the feed
    */
-  function _setHeartbeat(uint256 newHeartbeat) external override onlyPoolAdmin returns (uint256) {
+  function setHeartbeat(uint256 newHeartbeat) external override onlyPoolAdmin returns (uint256) {
     require(newHeartbeat <= MAX_AGE, Errors.AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE);
 
     emit NewHeartbeat(heartbeat, newHeartbeat);

--- a/contracts/protocol/tokenization/APoRToken.sol
+++ b/contracts/protocol/tokenization/APoRToken.sol
@@ -56,8 +56,7 @@ contract APoRToken is AToken, IAPoRToken {
     require(answer > 0, Errors.AT_POR_INVALID_ANSWER);
 
     // Check the answer is fresh enough (i.e., within the specified heartbeat)
-    uint256 heartbeat_ = heartbeat;
-    uint256 oldestAllowed = block.timestamp.sub(heartbeat_, Errors.AT_POR_INVALID_TIMESTAMP);
+    uint256 oldestAllowed = block.timestamp.sub(heartbeat, Errors.AT_POR_INVALID_TIMESTAMP);
     require(updatedAt >= oldestAllowed, Errors.AT_POR_ANSWER_TOO_OLD);
 
     // Get required info about underlying/reserves supply & decimals

--- a/contracts/protocol/tokenization/APoRToken.sol
+++ b/contracts/protocol/tokenization/APoRToken.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.6.12;
+
+import {AToken} from './AToken.sol';
+import {IAPoRToken} from '../../interfaces/IAPoRToken.sol';
+import {ILendingPool} from '../../interfaces/ILendingPool.sol';
+import {IChainlinkAggregatorV3} from '../../interfaces/IChainlinkAggregatorV3.sol';
+import {SafeMath} from '../../dependencies/openzeppelin/contracts/SafeMath.sol';
+import {IERC20Detailed} from '../../dependencies/openzeppelin/contracts/IERC20Detailed.sol';
+import {Errors} from '../libraries/helpers/Errors.sol';
+
+/**
+ * @title Aave's APoRToken (aToken with proof-of-reserves) Contract
+ * @notice AToken that checks reserves before minting
+ * @author Chainlink
+ */
+contract APoRToken is AToken, IAPoRToken {
+  using SafeMath for uint256;
+
+  uint256 public constant MAX_AGE = 7 days;
+  address public feed;
+  uint256 public heartbeat;
+
+  modifier onlyPoolAdmin {
+    require(
+      _msgSender() == ILendingPool(_pool).getAddressesProvider().getPoolAdmin(),
+      Errors.CALLER_NOT_POOL_ADMIN
+    );
+    _;
+  }
+
+  /**
+   * @notice Overriden mint function that checks the specified proof-of-reserves feed to
+   * ensure that the supply of the underlying assets is not greater than the reported
+   * reserves.
+   * @dev The proof-of-reserves check is bypassed if feed is not set.
+   * @param account The address to mint tokens to
+   * @param amount The amount of tokens to mint
+   */
+  function _mint(address account, uint256 amount) internal virtual override {
+    if (feed == address(0)) {
+      super._mint(account, amount);
+      return;
+    }
+
+    // Get latest proof-of-reserves from the feed
+    (, int256 answer, , uint256 updatedAt, ) = IChainlinkAggregatorV3(feed).latestRoundData();
+    require(answer > 0, Errors.AT_POR_INVALID_ANSWER);
+
+    // Check the answer is fresh enough (i.e., within the specified heartbeat)
+    uint256 heartbeat_ = heartbeat == 0 ? MAX_AGE : heartbeat;
+    uint256 oldestAllowed = block.timestamp.sub(heartbeat_, Errors.AT_POR_INVALID_TIMESTAMP);
+    require(updatedAt >= oldestAllowed, Errors.AT_POR_ANSWER_TOO_OLD);
+
+    // Get required info about underlying/reserves supply & decimals
+    uint256 underlyingSupply = IERC20Detailed(_underlyingAsset).totalSupply();
+    uint8 underlyingDecimals = IERC20Detailed(_underlyingAsset).decimals();
+    uint8 reserveDecimals = IChainlinkAggregatorV3(feed).decimals();
+    uint256 reserves = uint256(answer);
+    // Normalise underlying & reserve decimals
+    if (underlyingDecimals < reserveDecimals) {
+      underlyingSupply = underlyingSupply.mul(10**uint256(reserveDecimals - underlyingDecimals));
+    } else if (underlyingDecimals > reserveDecimals) {
+      reserves = reserves.mul(10**uint256(underlyingDecimals - reserveDecimals));
+    }
+
+    // Check that the supply of underlying tokens is NOT greater than the supply
+    // provided by the latest valid proof-of-reserves.
+    require(underlyingSupply <= reserves, Errors.AT_POR_UNDERLYING_GREATER_THAN_RESERVES);
+    super._mint(account, amount);
+  }
+
+  /**
+   * @notice Sets a new feed address
+   * @dev Admin function to set a new feed
+   * @param newFeed Address of the new feed
+   */
+  function _setFeed(address newFeed) external override onlyPoolAdmin returns (uint256) {
+    emit NewFeed(feed, newFeed);
+    feed = newFeed;
+  }
+
+  /**
+   * @notice Sets the feed's heartbeat expectation
+   * @dev Admin function to set the heartbeat
+   * @param newHeartbeat Value of the age of the latest update from the feed
+   */
+  function _setHeartbeat(uint256 newHeartbeat) external override onlyPoolAdmin returns (uint256) {
+    require(newHeartbeat <= MAX_AGE, Errors.AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE);
+
+    emit NewHeartbeat(heartbeat, newHeartbeat);
+    heartbeat = newHeartbeat;
+  }
+}

--- a/contracts/protocol/tokenization/APoRToken.sol
+++ b/contracts/protocol/tokenization/APoRToken.sol
@@ -83,8 +83,8 @@ contract APoRToken is AToken, IAPoRToken {
    * @param newFeed Address of the new feed
    */
   function _setFeed(address newFeed) external override onlyPoolAdmin returns (uint256) {
-    feed = newFeed;
     emit NewFeed(feed, newFeed);
+    feed = newFeed;
   }
 
   /**
@@ -95,7 +95,7 @@ contract APoRToken is AToken, IAPoRToken {
   function _setHeartbeat(uint256 newHeartbeat) external override onlyPoolAdmin returns (uint256) {
     require(newHeartbeat <= MAX_AGE, Errors.AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE);
 
-    heartbeat = newHeartbeat == 0 ? MAX_AGE : newHeartbeat;
     emit NewHeartbeat(heartbeat, newHeartbeat);
+    heartbeat = newHeartbeat == 0 ? MAX_AGE : newHeartbeat;
   }
 }

--- a/contracts/protocol/tokenization/APoRToken.sol
+++ b/contracts/protocol/tokenization/APoRToken.sol
@@ -30,6 +30,14 @@ contract APoRToken is AToken, IAPoRToken {
   }
 
   /**
+   * @dev This constructor only serves to set a default heartbeat.
+   *  Don't forget to use `initialize(...)` as you would with a regular AToken.
+   */
+  constructor() public {
+    heartbeat = MAX_AGE;
+  }
+
+  /**
    * @notice Overriden mint function that checks the specified proof-of-reserves feed to
    * ensure that the supply of the underlying assets is not greater than the reported
    * reserves.
@@ -48,7 +56,7 @@ contract APoRToken is AToken, IAPoRToken {
     require(answer > 0, Errors.AT_POR_INVALID_ANSWER);
 
     // Check the answer is fresh enough (i.e., within the specified heartbeat)
-    uint256 heartbeat_ = heartbeat == 0 ? MAX_AGE : heartbeat;
+    uint256 heartbeat_ = heartbeat;
     uint256 oldestAllowed = block.timestamp.sub(heartbeat_, Errors.AT_POR_INVALID_TIMESTAMP);
     require(updatedAt >= oldestAllowed, Errors.AT_POR_ANSWER_TOO_OLD);
 
@@ -76,8 +84,8 @@ contract APoRToken is AToken, IAPoRToken {
    * @param newFeed Address of the new feed
    */
   function _setFeed(address newFeed) external override onlyPoolAdmin returns (uint256) {
-    emit NewFeed(feed, newFeed);
     feed = newFeed;
+    emit NewFeed(feed, newFeed);
   }
 
   /**
@@ -88,7 +96,7 @@ contract APoRToken is AToken, IAPoRToken {
   function _setHeartbeat(uint256 newHeartbeat) external override onlyPoolAdmin returns (uint256) {
     require(newHeartbeat <= MAX_AGE, Errors.AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE);
 
+    heartbeat = newHeartbeat == 0 ? MAX_AGE : newHeartbeat;
     emit NewHeartbeat(heartbeat, newHeartbeat);
-    heartbeat = newHeartbeat;
   }
 }

--- a/helpers/contracts-deployments.ts
+++ b/helpers/contracts-deployments.ts
@@ -33,6 +33,7 @@ import {
   MintableDelegationERC20Factory,
   MintableERC20Factory,
   MockAggregatorFactory,
+  MockV3AggregatorFactory,
   MockATokenFactory,
   MockFlashLoanReceiverFactory,
   MockParaSwapAugustusFactory,
@@ -52,6 +53,7 @@ import {
   WETH9MockedFactory,
   WETHGatewayFactory,
   FlashLiquidationAdapterFactory,
+  APoRTokenFactory,
 } from '../types';
 import {
   withSaveAndVerify,
@@ -222,6 +224,18 @@ export const deployMockAggregator = async (price: tStringTokenSmallUnits, verify
     await new MockAggregatorFactory(await getFirstSigner()).deploy(price),
     eContractid.MockAggregator,
     [price],
+    verify
+  );
+
+export const deployMockV3Aggregator = async (
+  decimals: tStringTokenSmallUnits,
+  initialAnswer: tStringTokenSmallUnits,
+  verify?: boolean
+) =>
+  withSaveAndVerify(
+    await new MockV3AggregatorFactory(await getFirstSigner()).deploy(decimals, initialAnswer),
+    eContractid.MockAggregator,
+    [decimals, initialAnswer],
     verify
   );
 
@@ -406,6 +420,14 @@ export const deployGenericATokenImpl = async (verify: boolean) =>
   withSaveAndVerify(
     await new ATokenFactory(await getFirstSigner()).deploy(),
     eContractid.AToken,
+    [],
+    verify
+  );
+
+export const deployGenericAPoRTokenImpl = async (verify: boolean) =>
+  withSaveAndVerify(
+    await new APoRTokenFactory(await getFirstSigner()).deploy(),
+    eContractid.APoRToken,
     [],
     verify
   );
@@ -670,3 +692,35 @@ export const deployParaSwapLiquiditySwapAdapter = async (
     args,
     verify
   );
+
+export const deployAporToken = async (
+  [pool, underlyingAssetAddress, treasuryAddress, incentivesController, name, symbol]: [
+    tEthereumAddress,
+    tEthereumAddress,
+    tEthereumAddress,
+    tEthereumAddress,
+    string,
+    string
+  ],
+  verify: boolean
+) => {
+  const instance = await withSaveAndVerify(
+    await new APoRTokenFactory(await getFirstSigner()).deploy(),
+    eContractid.APoRToken,
+    [],
+    verify
+  );
+
+  await instance.initialize(
+    pool,
+    treasuryAddress,
+    underlyingAssetAddress,
+    incentivesController,
+    '18',
+    name,
+    symbol,
+    '0x10'
+  );
+
+  return instance;
+};

--- a/helpers/contracts-getters.ts
+++ b/helpers/contracts-getters.ts
@@ -75,6 +75,12 @@ export const getPriceOracle = async (address?: tEthereumAddress) =>
 
 export const getAToken = async (address?: tEthereumAddress) =>
   await ATokenFactory.connect(
+    address || (await getDb().get(`${eContractid.APoRToken}.${DRE.network.name}`).value()).address,
+    await getFirstSigner()
+  );
+
+export const getAPoRToken = async (address?: tEthereumAddress) =>
+  await ATokenFactory.connect(
     address || (await getDb().get(`${eContractid.AToken}.${DRE.network.name}`).value()).address,
     await getFirstSigner()
   );

--- a/helpers/contracts-getters.ts
+++ b/helpers/contracts-getters.ts
@@ -33,6 +33,7 @@ import {
   WETH9MockedFactory,
   WETHGatewayFactory,
   FlashLiquidationAdapterFactory,
+  APoRTokenFactory,
 } from '../types';
 import { IERC20DetailedFactory } from '../types/IERC20DetailedFactory';
 import { getEthersSigners, MockTokenMap } from './contracts-helpers';

--- a/helpers/contracts-getters.ts
+++ b/helpers/contracts-getters.ts
@@ -75,13 +75,13 @@ export const getPriceOracle = async (address?: tEthereumAddress) =>
 
 export const getAToken = async (address?: tEthereumAddress) =>
   await ATokenFactory.connect(
-    address || (await getDb().get(`${eContractid.APoRToken}.${DRE.network.name}`).value()).address,
+    address || (await getDb().get(`${eContractid.AToken}.${DRE.network.name}`).value()).address,
     await getFirstSigner()
   );
 
 export const getAPoRToken = async (address?: tEthereumAddress) =>
-  await ATokenFactory.connect(
-    address || (await getDb().get(`${eContractid.AToken}.${DRE.network.name}`).value()).address,
+  await APoRTokenFactory.connect(
+    address || (await getDb().get(`${eContractid.APoRToken}.${DRE.network.name}`).value()).address,
     await getFirstSigner()
   );
 

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -90,6 +90,7 @@ export enum eContractid {
   MockParaSwapAugustus = 'MockParaSwapAugustus',
   MockParaSwapAugustusRegistry = 'MockParaSwapAugustusRegistry',
   ParaSwapLiquiditySwapAdapter = 'ParaSwapLiquiditySwapAdapter',
+  APoRToken = 'APoRToken',
 }
 
 /*
@@ -181,6 +182,18 @@ export enum ProtocolErrors {
   RC_INVALID_DECIMALS = '70',
   RC_INVALID_RESERVE_FACTOR = '71',
   LPAPR_INVALID_ADDRESSES_PROVIDER_ID = '72',
+  VL_INCONSISTENT_FLASHLOAN_PARAMS = '73',
+  LP_INCONSISTENT_PARAMS_LENGTH = '74',
+  UL_INVALID_INDEX = '77',
+  LP_NOT_CONTRACT = '78',
+  SDT_STABLE_DEBT_OVERFLOW = '79',
+  SDT_BURN_EXCEEDS_BALANCE = '80',
+  AT_POR_INVALID_ANSWER = '81',
+  AT_POR_INVALID_TIMESTAMP = '82',
+  AT_POR_ANSWER_TOO_OLD = '83',
+  AT_POR_INVALID_DECIMALS = '84',
+  AT_POR_UNDERLYING_GREATER_THAN_RESERVES = '85',
+  AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE = '86',
 
   // old
 

--- a/markets/aave/reservesConfigs.ts
+++ b/markets/aave/reservesConfigs.ts
@@ -225,7 +225,7 @@ export const strategyWBTC: IReserveParams = {
   borrowingEnabled: true,
   stableBorrowRateEnabled: true,
   reserveDecimals: '8',
-  aTokenImpl: eContractid.AToken,
+  aTokenImpl: eContractid.APoRToken,
   reserveFactor: '2000'
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14793,7 +14793,7 @@
               }
             },
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {

--- a/test-suites/test-aave/aportoken.spec.ts
+++ b/test-suites/test-aave/aportoken.spec.ts
@@ -1,305 +1,240 @@
 import { network } from 'hardhat';
-import { MAX_UINT_AMOUNT, ZERO_ADDRESS } from '../../helpers/constants';
-import { BUIDLEREVM_CHAINID } from '../../helpers/buidler-constants';
-import {
-  buildPermitParams,
-  convertToCurrencyDecimals,
-  getSignatureFromTypedData,
-} from '../../helpers/contracts-helpers';
+import { ZERO_ADDRESS } from '../../helpers/constants';
+import { convertToCurrencyDecimals } from '../../helpers/contracts-helpers';
 import { expect } from 'chai';
 import { BigNumber, BigNumberish, ethers } from 'ethers';
 import { ProtocolErrors } from '../../helpers/types';
-import { makeSuite, TestEnv } from './helpers/make-suite';
-import { DRE } from '../../helpers/misc-utils';
-import {
-  ConfigNames,
-  getATokenDomainSeparatorPerNetwork,
-  getTreasuryAddress,
-  loadPoolConfig,
-} from '../../helpers/configuration';
-import { waitForTx } from '../../helpers/misc-utils';
-import {
-  deployAporToken,
-  deployMockV3Aggregator,
-  deployMockVariableDebtToken,
-} from '../../helpers/contracts-deployments';
+import { makeSuite, SignerWithAddress, TestEnv } from './helpers/make-suite';
+import { deployMockV3Aggregator } from '../../helpers/contracts-deployments';
 import AaveConfig from '../../markets/aave';
-import {
-  APoRToken,
-  AToken,
-  ATokenFactory,
-  Errors,
-  ErrorsFactory,
-  LendingPoolAddressesProviderFactory,
-  MintableERC20,
-  MockV3Aggregator,
-} from '../../types';
-import { getMintableERC20 } from '../../helpers/contracts-getters';
-
-const { parseEther } = ethers.utils;
+import { APoRToken, LendingPool, MintableERC20, MockV3Aggregator } from '../../types';
 
 // = base * 10^{exponent}
 const exp = (base: BigNumberish, exponent: BigNumberish): BigNumber => {
   return BigNumber.from(base).mul(BigNumber.from(10).pow(exponent));
 };
 
-makeSuite(
-  'APoRToken: Mint with proof-of-reserves check',
-  (testEnv: TestEnv) => {
-    const WBTC_AGG_INITIAL_ANSWER = exp(1_000_000, 8).toString(); // "1M WBTC in reserves"
-    const poolConfig = loadPoolConfig(ConfigNames.Commons);
-    let aporWbtc = <APoRToken>{};
-    let mockV3Aggregator: MockV3Aggregator;
+makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => {
+  const ONE_DAY_SECONDS = 24 * 60 * 60; // seconds in a day
+  const WBTC_FEED_INITIAL_ANSWER = exp(1_000_000, 8).toString(); // "1M WBTC in reserves"
+  let wbtc: MintableERC20;
+  let aWbtc: APoRToken;
+  let users: SignerWithAddress[];
+  let pool: LendingPool;
+  let regularUser: SignerWithAddress;
+  let amountToDeposit;
+  let mockV3Aggregator: MockV3Aggregator;
 
-    beforeEach(async () => {
-      // Deploy mock V3 aggregator as the PoR feed
-      mockV3Aggregator = await deployMockV3Aggregator('8', WBTC_AGG_INITIAL_ANSWER);
+  beforeEach(async () => {
+    // `testEnv` is initialised in an async `before` hook up the tree,
+    // so they must be initialised here
+    wbtc = testEnv.wbtc;
+    aWbtc = testEnv.aWbtc;
+    users = testEnv.users;
+    pool = testEnv.pool;
+    regularUser = users[1];
+
+    // Mint some fake WBTC
+    amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+    await wbtc.connect(regularUser.signer).mint(amountToDeposit);
+    await wbtc.connect(regularUser.signer).approve(pool.address, amountToDeposit);
+
+    // Deploy mock V3 aggregator as the PoR feed
+    mockV3Aggregator = await deployMockV3Aggregator('8', WBTC_FEED_INITIAL_ANSWER);
+  });
+
+  describe('Proof-of-reserves check', () => {
+    it('should mint successfully when feed is unset', async () => {
+      // Make sure feed is unset
+      expect(await aWbtc.feed()).to.equal(ZERO_ADDRESS);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(regularUser.address);
+      await pool
+        .connect(regularUser.signer)
+        .deposit(wbtc.address, amountToDeposit, regularUser.address, '0');
+      expect(await aWbtc.balanceOf(regularUser.address)).to.equal(
+        balanceBefore.add(amountToDeposit)
+      );
     });
 
-    describe('Proof-of-reserves check', () => {
-      it('should mint successfully when feed is unset', async () => {
-        const { wbtc, aWbtc, users, pool } = testEnv;
-        const user = users[1];
+    it('should mint successfully when feed is set, but heartbeat is unset', async () => {
+      // Make sure feed and heartbeat values are what we're testing for
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(0);
+      expect(await aWbtc.heartbeat()).to.equal(0);
 
-        // Mint some fake WBTC
-        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-        await wbtc.connect(user.signer).mint(amountToDeposit);
-        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
-
-        // Make sure feed is unset
-        expect(await aWbtc.feed()).to.equal(ZERO_ADDRESS);
-
-        // Deposit WBTC - the aToken will call the feed before minting to check PoR
-        const balanceBefore = await aWbtc.balanceOf(user.address);
-        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
-      });
-
-      it('should mint successfully when feed is set, but heartbeat is unset', async () => {
-        const { wbtc, aWbtc, users, pool } = testEnv;
-        const user = users[1];
-
-        // Mint some fake WBTC
-        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-        await wbtc.connect(user.signer).mint(amountToDeposit);
-        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
-
-        // Make sure feed and heartbeat values are what we're testing for
-        await aWbtc._setFeed(mockV3Aggregator.address);
-        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-        await aWbtc._setHeartbeat(0);
-        expect(await aWbtc.heartbeat()).to.equal(0);
-
-        // Deposit WBTC - the aToken will call the feed before minting to check PoR
-        const balanceBefore = await aWbtc.balanceOf(user.address);
-        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-        expect(await aWbtc.balanceOf(user.address)).to.equal(amountToDeposit.add(balanceBefore));
-      });
-
-      it('should mint successfully when both feed and heartbeat are set', async () => {
-        const { wbtc, aWbtc, users, pool } = testEnv;
-        const user = users[1];
-
-        // Mint some fake WBTC
-        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-        await wbtc.connect(user.signer).mint(amountToDeposit);
-        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
-
-        // Make sure feed and heartbeat values are what we're testing for
-        await aWbtc._setFeed(mockV3Aggregator.address);
-        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-        await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
-        expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
-
-        // Deposit WBTC - the aToken will call the feed before minting to check PoR
-        const balanceBefore = await aWbtc.balanceOf(user.address);
-        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
-      });
-
-      it('should mint successfully when feed decimals < underlying decimals', async () => {
-        const { wbtc, aWbtc, users, pool } = testEnv;
-        const user = users[1];
-
-        // Mint some fake WBTC
-        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-        await wbtc.connect(user.signer).mint(amountToDeposit);
-        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
-
-        // Re-deploy aggregator with fewer decimals
-        const currentWbtcSupply = await wbtc.totalSupply();
-        mockV3Aggregator = await deployMockV3Aggregator(
-          '6',
-          currentWbtcSupply.div(exp(1, 2)).toString()
-        );
-
-        // Make sure feed and heartbeat values are set
-        await aWbtc._setFeed(mockV3Aggregator.address);
-        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-        await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
-        expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
-
-        // Deposit WBTC - the aToken will call the feed before minting to check PoR
-        const balanceBefore = await aWbtc.balanceOf(user.address);
-        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
-      });
-
-      it('should mint successfully when feed decimals > underlying decimals', async () => {
-        const { wbtc, aWbtc, users, pool } = testEnv;
-        const user = users[1];
-
-        // Mint some fake WBTC
-        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-        await wbtc.connect(user.signer).mint(amountToDeposit);
-        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
-
-        // Re-deploy aggregator with more decimals
-        const currentWbtcSupply = await wbtc.totalSupply();
-        mockV3Aggregator = await deployMockV3Aggregator(
-          '18',
-          currentWbtcSupply.mul(exp(1, 10)).toString()
-        );
-
-        // Make sure feed and heartbeat values are set
-        await aWbtc._setFeed(mockV3Aggregator.address);
-        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-        await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
-        expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
-
-        // Deposit WBTC - the aToken will call the feed before minting to check PoR
-        const balanceBefore = await aWbtc.balanceOf(user.address);
-        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
-      });
-
-      it('should revert if underlying supply > proof-of-reserves', async () => {
-        const { wbtc, aWbtc, users, pool } = testEnv;
-        const user = users[1];
-
-        // Mint some fake WBTC
-        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-        await wbtc.connect(user.signer).mint(amountToDeposit);
-        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
-
-        // Re-deploy aggregator with fewer WBTC in reserves
-        const currentWbtcSupply = await wbtc.totalSupply();
-        const notEnoughReserves = currentWbtcSupply.sub('1');
-        mockV3Aggregator = await deployMockV3Aggregator('18', notEnoughReserves.toString());
-
-        // Make sure feed and heartbeat values are set
-        await aWbtc._setFeed(mockV3Aggregator.address);
-        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-        await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
-        expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
-
-        // Deposit WBTC - the aToken will call the feed before minting to check PoR
-        const balanceBefore = await aWbtc.balanceOf(user.address);
-        await expect(
-          pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0')
-        ).to.be.revertedWith(ProtocolErrors.AT_POR_UNDERLYING_GREATER_THAN_RESERVES);
-        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore);
-      });
-
-      it('should revert if the feed is not updated within the heartbeat', async () => {
-        const { wbtc, aWbtc, users, pool } = testEnv;
-        const user = users[1];
-
-        // Mint some fake WBTC
-        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-        await wbtc.connect(user.signer).mint(amountToDeposit);
-        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
-
-        // Re-deploy aggregator with fewer decimals
-        mockV3Aggregator = await deployMockV3Aggregator('18', WBTC_AGG_INITIAL_ANSWER);
-
-        // Make sure feed and heartbeat values are set
-        await aWbtc._setFeed(mockV3Aggregator.address);
-        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-        const heartbeatSeconds = 24 * 60 * 60;
-        await aWbtc._setHeartbeat(heartbeatSeconds); // 1 day, in seconds
-        expect(await aWbtc.heartbeat()).to.equal(heartbeatSeconds);
-
-        // Heartbeat is set to 1 day, so fast-forward 2 days
-        await network.provider.send('evm_increaseTime', [2 * heartbeatSeconds]);
-
-        // Deposit WBTC - the aToken will call the feed before minting to check PoR
-        const balanceBefore = await aWbtc.balanceOf(user.address);
-        await expect(
-          pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0')
-        ).to.be.revertedWith(ProtocolErrors.AT_POR_ANSWER_TOO_OLD);
-        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore);
-      });
-
-      it('should revert if feed returns an invalid answer', async () => {
-        const { wbtc, aWbtc, users, pool } = testEnv;
-        const user = users[1];
-
-        // Mint some fake WBTC
-        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-        await wbtc.connect(user.signer).mint(amountToDeposit);
-        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
-
-        // Update feed with invalid answer
-        await mockV3Aggregator.updateAnswer(0);
-
-        // Make sure feed and heartbeat values are set
-        await aWbtc._setFeed(mockV3Aggregator.address);
-        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-        const heartbeatSeconds = 24 * 60 * 60;
-        await aWbtc._setHeartbeat(heartbeatSeconds); // 1 day, in seconds
-        expect(await aWbtc.heartbeat()).to.equal(heartbeatSeconds);
-
-        // Deposit WBTC - the aToken will call the feed before minting to check PoR
-        const balanceBefore = await aWbtc.balanceOf(user.address);
-        await expect(
-          pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0')
-        ).to.be.revertedWith(ProtocolErrors.AT_POR_INVALID_ANSWER);
-        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore);
-      });
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(regularUser.address);
+      await pool
+        .connect(regularUser.signer)
+        .deposit(wbtc.address, amountToDeposit, regularUser.address, '0');
+      expect(await aWbtc.balanceOf(regularUser.address)).to.equal(
+        amountToDeposit.add(balanceBefore)
+      );
     });
 
-    describe('Set feed', () => {
-      it('should only be callable by poolAdmin', async () => {
-        const { aWbtc, users } = testEnv;
-        const regularUser = users[1];
-        await expect(
-          aWbtc.connect(regularUser.signer)._setFeed(mockV3Aggregator.address)
-        ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
-      });
+    it('should mint successfully when both feed and heartbeat are set', async () => {
+      // Make sure feed and heartbeat values are what we're testing for
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
 
-      it('should unset feed if called by pool admin', async () => {
-        const { aWbtc, users } = testEnv;
-        await aWbtc._setFeed(ZERO_ADDRESS);
-        expect(await aWbtc.feed()).to.equal(ZERO_ADDRESS);
-      });
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(regularUser.address);
+      await pool
+        .connect(regularUser.signer)
+        .deposit(wbtc.address, amountToDeposit, regularUser.address, '0');
+      expect(await aWbtc.balanceOf(regularUser.address)).to.equal(
+        balanceBefore.add(amountToDeposit)
+      );
     });
 
-    describe('Set heartbeat', () => {
-      it('should only be callable by poolAdmin', async () => {
-        const { aWbtc, users } = testEnv;
-        const regularUser = users[1];
-        const oneDaySeconds = 24 * 60 * 60;
-        await expect(
-          aWbtc.connect(regularUser.signer)._setHeartbeat(oneDaySeconds)
-        ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
-      });
+    it('should mint successfully when feed decimals < underlying decimals', async () => {
+      // Re-deploy aggregator with fewer decimals
+      const currentWbtcSupply = await wbtc.totalSupply();
+      mockV3Aggregator = await deployMockV3Aggregator(
+        '6',
+        currentWbtcSupply.div(exp(1, 2)).toString()
+      );
 
-      it('should revert if newHeartbeat > MAX_AGE', async () => {
-        const { aWbtc, users } = testEnv;
-        const regularUser = users[1];
-        const eightDaySeconds = 8 * 24 * 60 * 60;
-        await expect(aWbtc._setHeartbeat(eightDaySeconds)).to.be.revertedWith(
-          ProtocolErrors.AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE
-        );
-      });
+      // Make sure feed and heartbeat values are set
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
 
-      it('should unset heartbeat if called by pool admin', async () => {
-        const { aWbtc } = testEnv;
-        await aWbtc._setHeartbeat(0);
-        expect(await aWbtc.heartbeat()).to.equal(0);
-      });
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(regularUser.address);
+      await pool
+        .connect(regularUser.signer)
+        .deposit(wbtc.address, amountToDeposit, regularUser.address, '0');
+      expect(await aWbtc.balanceOf(regularUser.address)).to.equal(
+        balanceBefore.add(amountToDeposit)
+      );
     });
-  },
-  { isolate: true }
-);
+
+    it('should mint successfully when feed decimals > underlying decimals', async () => {
+      // Re-deploy aggregator with more decimals
+      const currentWbtcSupply = await wbtc.totalSupply();
+      mockV3Aggregator = await deployMockV3Aggregator(
+        '18',
+        currentWbtcSupply.mul(exp(1, 10)).toString()
+      );
+
+      // Make sure feed and heartbeat values are set
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(regularUser.address);
+      await pool
+        .connect(regularUser.signer)
+        .deposit(wbtc.address, amountToDeposit, regularUser.address, '0');
+      expect(await aWbtc.balanceOf(regularUser.address)).to.equal(
+        balanceBefore.add(amountToDeposit)
+      );
+    });
+
+    it('should revert if underlying supply > proof-of-reserves', async () => {
+      // Re-deploy aggregator with fewer WBTC in reserves
+      const currentWbtcSupply = await wbtc.totalSupply();
+      const notEnoughReserves = currentWbtcSupply.sub('1');
+      mockV3Aggregator = await deployMockV3Aggregator('18', notEnoughReserves.toString());
+
+      // Make sure feed and heartbeat values are set
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(regularUser.address);
+      await expect(
+        pool
+          .connect(regularUser.signer)
+          .deposit(wbtc.address, amountToDeposit, regularUser.address, '0')
+      ).to.be.revertedWith(ProtocolErrors.AT_POR_UNDERLYING_GREATER_THAN_RESERVES);
+      expect(await aWbtc.balanceOf(regularUser.address)).to.equal(balanceBefore);
+    });
+
+    it('should revert if the feed is not updated within the heartbeat', async () => {
+      // Re-deploy aggregator with fewer decimals
+      mockV3Aggregator = await deployMockV3Aggregator('18', WBTC_FEED_INITIAL_ANSWER);
+
+      // Make sure feed and heartbeat values are set
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
+
+      // Heartbeat is set to 1 day, so fast-forward 2 days
+      await network.provider.send('evm_increaseTime', [2 * ONE_DAY_SECONDS]);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(regularUser.address);
+      await expect(
+        pool
+          .connect(regularUser.signer)
+          .deposit(wbtc.address, amountToDeposit, regularUser.address, '0')
+      ).to.be.revertedWith(ProtocolErrors.AT_POR_ANSWER_TOO_OLD);
+      expect(await aWbtc.balanceOf(regularUser.address)).to.equal(balanceBefore);
+    });
+
+    it('should revert if feed returns an invalid answer', async () => {
+      // Update feed with invalid answer
+      await mockV3Aggregator.updateAnswer(0);
+
+      // Make sure feed and heartbeat values are set
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(ONE_DAY_SECONDS); // 1 day, in seconds
+      expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(regularUser.address);
+      await expect(
+        pool
+          .connect(regularUser.signer)
+          .deposit(wbtc.address, amountToDeposit, regularUser.address, '0')
+      ).to.be.revertedWith(ProtocolErrors.AT_POR_INVALID_ANSWER);
+      expect(await aWbtc.balanceOf(regularUser.address)).to.equal(balanceBefore);
+    });
+  });
+
+  describe('Set feed', () => {
+    it('should only be callable by poolAdmin', async () => {
+      await expect(
+        aWbtc.connect(regularUser.signer)._setFeed(mockV3Aggregator.address)
+      ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
+    });
+
+    it('should unset feed if called by pool admin', async () => {
+      await aWbtc._setFeed(ZERO_ADDRESS);
+      expect(await aWbtc.feed()).to.equal(ZERO_ADDRESS);
+    });
+  });
+
+  describe('Set heartbeat', () => {
+    it('should only be callable by poolAdmin', async () => {
+      await expect(
+        aWbtc.connect(regularUser.signer)._setHeartbeat(ONE_DAY_SECONDS)
+      ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
+    });
+
+    it('should revert if newHeartbeat > MAX_AGE', async () => {
+      await expect(aWbtc._setHeartbeat(8 * ONE_DAY_SECONDS)).to.be.revertedWith(
+        ProtocolErrors.AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE
+      );
+    });
+
+    it('should unset heartbeat if called by pool admin', async () => {
+      await aWbtc._setHeartbeat(0);
+      expect(await aWbtc.heartbeat()).to.equal(0);
+    });
+  });
+});

--- a/test-suites/test-aave/aportoken.spec.ts
+++ b/test-suites/test-aave/aportoken.spec.ts
@@ -1,0 +1,234 @@
+import { network } from 'hardhat';
+import { MAX_UINT_AMOUNT, ZERO_ADDRESS } from '../../helpers/constants';
+import { BUIDLEREVM_CHAINID } from '../../helpers/buidler-constants';
+import {
+  buildPermitParams,
+  convertToCurrencyDecimals,
+  getSignatureFromTypedData,
+} from '../../helpers/contracts-helpers';
+import { expect } from 'chai';
+import { BigNumber, BigNumberish, ethers } from 'ethers';
+import { ProtocolErrors } from '../../helpers/types';
+import { makeSuite, TestEnv } from './helpers/make-suite';
+import { DRE } from '../../helpers/misc-utils';
+import {
+  ConfigNames,
+  getATokenDomainSeparatorPerNetwork,
+  getTreasuryAddress,
+  loadPoolConfig,
+} from '../../helpers/configuration';
+import { waitForTx } from '../../helpers/misc-utils';
+import {
+  deployAporToken,
+  deployMockV3Aggregator,
+  deployMockVariableDebtToken,
+} from '../../helpers/contracts-deployments';
+import AaveConfig from '../../markets/aave';
+import {
+  APoRToken,
+  AToken,
+  ATokenFactory,
+  Errors,
+  ErrorsFactory,
+  LendingPoolAddressesProviderFactory,
+  MintableERC20,
+  MockV3Aggregator,
+} from '../../types';
+import { getMintableERC20 } from '../../helpers/contracts-getters';
+
+const { parseEther } = ethers.utils;
+
+// = base * 10^{exponent}
+const exp = (base: BigNumberish, exponent: BigNumberish): BigNumber => {
+  return BigNumber.from(base).mul(BigNumber.from(10).pow(exponent));
+};
+
+makeSuite(
+  'APoRToken: Mint with proof-of-reserves check',
+  (testEnv: TestEnv) => {
+    const WBTC_AGG_INITIAL_ANSWER = exp(1_000_000, 8).toString(); // "1M WBTC in reserves"
+    const poolConfig = loadPoolConfig(ConfigNames.Commons);
+    let aporWbtc = <APoRToken>{};
+    let mockV3Aggregator: MockV3Aggregator;
+
+    beforeEach(async () => {
+      // Deploy mock V3 aggregator as the PoR feed
+      mockV3Aggregator = await deployMockV3Aggregator('8', WBTC_AGG_INITIAL_ANSWER);
+    });
+
+    it('should mint successfully when feed is unset', async () => {
+      const { wbtc, aWbtc, users, pool } = testEnv;
+      const user = users[1];
+
+      // Mint some fake WBTC
+      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+      await wbtc.connect(user.signer).mint(amountToDeposit);
+      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+
+      // Make sure feed is unset
+      expect(await aWbtc.feed()).to.equal(ZERO_ADDRESS);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(user.address);
+      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
+    });
+
+    it('should mint successfully when feed is set, but heartbeat is unset', async () => {
+      const { wbtc, aWbtc, users, pool } = testEnv;
+      const user = users[1];
+
+      // Mint some fake WBTC
+      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+      await wbtc.connect(user.signer).mint(amountToDeposit);
+      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+
+      // Make sure feed and heartbeat values are what we're testing for
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(0);
+      expect(await aWbtc.heartbeat()).to.equal(0);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(user.address);
+      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+      expect(await aWbtc.balanceOf(user.address)).to.equal(amountToDeposit.add(balanceBefore));
+    });
+
+    it('should mint successfully when both feed and heartbeat are set', async () => {
+      const { wbtc, aWbtc, users, pool } = testEnv;
+      const user = users[1];
+
+      // Mint some fake WBTC
+      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+      await wbtc.connect(user.signer).mint(amountToDeposit);
+      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+
+      // Make sure feed and heartbeat values are what we're testing for
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
+      expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(user.address);
+      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
+    });
+
+    it('should mint successfully when feed decimals < underlying decimals', async () => {
+      const { wbtc, aWbtc, users, pool } = testEnv;
+      const user = users[1];
+
+      // Mint some fake WBTC
+      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+      await wbtc.connect(user.signer).mint(amountToDeposit);
+      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+
+      // Re-deploy aggregator with fewer decimals
+      const currentWbtcSupply = await wbtc.totalSupply();
+      mockV3Aggregator = await deployMockV3Aggregator(
+        '6',
+        currentWbtcSupply.div(exp(1, 2)).toString()
+      );
+
+      // Make sure feed and heartbeat values are set
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
+      expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(user.address);
+      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
+    });
+
+    it('should mint successfully when feed decimals > underlying decimals', async () => {
+      const { wbtc, aWbtc, users, pool } = testEnv;
+      const user = users[1];
+
+      // Mint some fake WBTC
+      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+      await wbtc.connect(user.signer).mint(amountToDeposit);
+      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+
+      // Re-deploy aggregator with more decimals
+      const currentWbtcSupply = await wbtc.totalSupply();
+      mockV3Aggregator = await deployMockV3Aggregator(
+        '18',
+        currentWbtcSupply.mul(exp(1, 10)).toString()
+      );
+
+      // Make sure feed and heartbeat values are set
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
+      expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(user.address);
+      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
+    });
+
+    it('should revert if underlying supply > proof-of-reserves', async () => {
+      const { wbtc, aWbtc, users, pool } = testEnv;
+      const user = users[1];
+
+      // Mint some fake WBTC
+      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+      await wbtc.connect(user.signer).mint(amountToDeposit);
+      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+
+      // Re-deploy aggregator with fewer WBTC in reserves
+      const currentWbtcSupply = await wbtc.totalSupply();
+      const notEnoughReserves = currentWbtcSupply.sub('1');
+      mockV3Aggregator = await deployMockV3Aggregator('18', notEnoughReserves.toString());
+
+      // Make sure feed and heartbeat values are set
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
+      expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(user.address);
+      await expect(
+        pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0')
+      ).to.be.revertedWith(ProtocolErrors.AT_POR_UNDERLYING_GREATER_THAN_RESERVES);
+      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore);
+    });
+
+    it('should revert if the feed is not updated within the heartbeat', async () => {
+      const { wbtc, aWbtc, users, pool } = testEnv;
+      const user = users[1];
+
+      // Mint some fake WBTC
+      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+      await wbtc.connect(user.signer).mint(amountToDeposit);
+      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+
+      // Re-deploy aggregator with fewer decimals
+      mockV3Aggregator = await deployMockV3Aggregator('18', WBTC_AGG_INITIAL_ANSWER);
+
+      // Make sure feed and heartbeat values are set
+      await aWbtc._setFeed(mockV3Aggregator.address);
+      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+      const heartbeatSeconds = 24 * 60 * 60;
+      await aWbtc._setHeartbeat(heartbeatSeconds); // 1 day, in seconds
+      expect(await aWbtc.heartbeat()).to.equal(heartbeatSeconds);
+
+      // Heartbeat is set to 1 day, so fast-forward 2 days
+      await network.provider.send('evm_increaseTime', [2 * heartbeatSeconds]);
+
+      // Deposit WBTC - the aToken will call the feed before minting to check PoR
+      const balanceBefore = await aWbtc.balanceOf(user.address);
+      await expect(
+        pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0')
+      ).to.be.revertedWith(ProtocolErrors.AT_POR_ANSWER_TOO_OLD);
+      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore);
+    });
+  },
+  { isolate: true }
+);

--- a/test-suites/test-aave/aportoken.spec.ts
+++ b/test-suites/test-aave/aportoken.spec.ts
@@ -58,12 +58,12 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
       );
     });
 
-    it('should mint successfully when feed is set, but heartbeat is unset', async () => {
+    it('should mint successfully when feed is set, but heartbeat is unset (defaulting to MAX_AGE)', async () => {
       // Make sure feed and heartbeat values are what we're testing for
       await aWbtc._setFeed(mockV3Aggregator.address);
       expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
       await aWbtc._setHeartbeat(0);
-      expect(await aWbtc.heartbeat()).to.equal(0);
+      expect(await aWbtc.heartbeat()).to.equal(await aWbtc.MAX_AGE());
 
       // Deposit WBTC - the aToken will call the feed before minting to check PoR
       const balanceBefore = await aWbtc.balanceOf(regularUser.address);
@@ -232,9 +232,9 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
       );
     });
 
-    it('should unset heartbeat if called by pool admin', async () => {
+    it('should set heartbeat to MAX_AGE by default if called by pool admin with 0', async () => {
       await aWbtc._setHeartbeat(0);
-      expect(await aWbtc.heartbeat()).to.equal(0);
+      expect(await aWbtc.heartbeat()).to.equal(await aWbtc.MAX_AGE());
     });
   });
 });

--- a/test-suites/test-aave/aportoken.spec.ts
+++ b/test-suites/test-aave/aportoken.spec.ts
@@ -60,9 +60,9 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
 
     it('should mint successfully when feed is set, but heartbeat is unset (defaulting to MAX_AGE)', async () => {
       // Make sure feed and heartbeat values are what we're testing for
-      await aWbtc._setFeed(mockV3Aggregator.address);
+      await aWbtc.setFeed(mockV3Aggregator.address);
       expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(0);
+      await aWbtc.setHeartbeat(0);
       expect(await aWbtc.heartbeat()).to.equal(await aWbtc.MAX_AGE());
 
       // Deposit WBTC - the aToken will call the feed before minting to check PoR
@@ -77,9 +77,9 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
 
     it('should mint successfully when both feed and heartbeat are set', async () => {
       // Make sure feed and heartbeat values are what we're testing for
-      await aWbtc._setFeed(mockV3Aggregator.address);
+      await aWbtc.setFeed(mockV3Aggregator.address);
       expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      await aWbtc.setHeartbeat(ONE_DAY_SECONDS);
       expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
 
       // Deposit WBTC - the aToken will call the feed before minting to check PoR
@@ -101,9 +101,9 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
       );
 
       // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
+      await aWbtc.setFeed(mockV3Aggregator.address);
       expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      await aWbtc.setHeartbeat(ONE_DAY_SECONDS);
       expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
 
       // Deposit WBTC - the aToken will call the feed before minting to check PoR
@@ -125,9 +125,9 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
       );
 
       // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
+      await aWbtc.setFeed(mockV3Aggregator.address);
       expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      await aWbtc.setHeartbeat(ONE_DAY_SECONDS);
       expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
 
       // Deposit WBTC - the aToken will call the feed before minting to check PoR
@@ -146,9 +146,9 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
       mockV3Aggregator = await deployMockV3Aggregator('8', currentWbtcSupply.toString());
 
       // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
+      await aWbtc.setFeed(mockV3Aggregator.address);
       expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      await aWbtc.setHeartbeat(ONE_DAY_SECONDS);
       expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
 
       // Deposit WBTC - the aToken will call the feed before minting to check PoR
@@ -168,9 +168,9 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
       mockV3Aggregator = await deployMockV3Aggregator('8', notEnoughReserves.toString());
 
       // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
+      await aWbtc.setFeed(mockV3Aggregator.address);
       expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      await aWbtc.setHeartbeat(ONE_DAY_SECONDS);
       expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
 
       // Deposit WBTC - the aToken will call the feed before minting to check PoR
@@ -187,9 +187,9 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
       mockV3Aggregator = await deployMockV3Aggregator('8', WBTC_FEED_INITIAL_ANSWER);
 
       // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
+      await aWbtc.setFeed(mockV3Aggregator.address);
       expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(ONE_DAY_SECONDS);
+      await aWbtc.setHeartbeat(ONE_DAY_SECONDS);
       expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
 
       // Heartbeat is set to 1 day, so fast-forward 2 days
@@ -210,9 +210,9 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
       await mockV3Aggregator.updateAnswer(0);
 
       // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
+      await aWbtc.setFeed(mockV3Aggregator.address);
       expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(ONE_DAY_SECONDS); // 1 day, in seconds
+      await aWbtc.setHeartbeat(ONE_DAY_SECONDS); // 1 day, in seconds
       expect(await aWbtc.heartbeat()).to.equal(ONE_DAY_SECONDS);
 
       // Deposit WBTC - the aToken will call the feed before minting to check PoR
@@ -229,12 +229,12 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
   describe('Set feed', () => {
     it('should only be callable by poolAdmin', async () => {
       await expect(
-        aWbtc.connect(regularUser.signer)._setFeed(mockV3Aggregator.address)
+        aWbtc.connect(regularUser.signer).setFeed(mockV3Aggregator.address)
       ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
     });
 
     it('should unset feed if called by pool admin', async () => {
-      await aWbtc._setFeed(ZERO_ADDRESS);
+      await aWbtc.setFeed(ZERO_ADDRESS);
       expect(await aWbtc.feed()).to.equal(ZERO_ADDRESS);
     });
   });
@@ -242,18 +242,18 @@ makeSuite('APoRToken: Mint with proof-of-reserves check', (testEnv: TestEnv) => 
   describe('Set heartbeat', () => {
     it('should only be callable by poolAdmin', async () => {
       await expect(
-        aWbtc.connect(regularUser.signer)._setHeartbeat(ONE_DAY_SECONDS)
+        aWbtc.connect(regularUser.signer).setHeartbeat(ONE_DAY_SECONDS)
       ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
     });
 
     it('should revert if newHeartbeat > MAX_AGE', async () => {
-      await expect(aWbtc._setHeartbeat(8 * ONE_DAY_SECONDS)).to.be.revertedWith(
+      await expect(aWbtc.setHeartbeat(8 * ONE_DAY_SECONDS)).to.be.revertedWith(
         ProtocolErrors.AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE
       );
     });
 
     it('should set heartbeat to MAX_AGE by default if called by pool admin with 0', async () => {
-      await aWbtc._setHeartbeat(0);
+      await aWbtc.setHeartbeat(0);
       expect(await aWbtc.heartbeat()).to.equal(await aWbtc.MAX_AGE());
     });
   });

--- a/test-suites/test-aave/aportoken.spec.ts
+++ b/test-suites/test-aave/aportoken.spec.ts
@@ -56,178 +56,222 @@ makeSuite(
       mockV3Aggregator = await deployMockV3Aggregator('8', WBTC_AGG_INITIAL_ANSWER);
     });
 
-    it('should mint successfully when feed is unset', async () => {
-      const { wbtc, aWbtc, users, pool } = testEnv;
-      const user = users[1];
+    describe('Proof-of-reserves check', () => {
+      it('should mint successfully when feed is unset', async () => {
+        const { wbtc, aWbtc, users, pool } = testEnv;
+        const user = users[1];
 
-      // Mint some fake WBTC
-      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-      await wbtc.connect(user.signer).mint(amountToDeposit);
-      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+        // Mint some fake WBTC
+        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+        await wbtc.connect(user.signer).mint(amountToDeposit);
+        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
 
-      // Make sure feed is unset
-      expect(await aWbtc.feed()).to.equal(ZERO_ADDRESS);
+        // Make sure feed is unset
+        expect(await aWbtc.feed()).to.equal(ZERO_ADDRESS);
 
-      // Deposit WBTC - the aToken will call the feed before minting to check PoR
-      const balanceBefore = await aWbtc.balanceOf(user.address);
-      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
-    });
+        // Deposit WBTC - the aToken will call the feed before minting to check PoR
+        const balanceBefore = await aWbtc.balanceOf(user.address);
+        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
+      });
 
-    it('should mint successfully when feed is set, but heartbeat is unset', async () => {
-      const { wbtc, aWbtc, users, pool } = testEnv;
-      const user = users[1];
+      it('should mint successfully when feed is set, but heartbeat is unset', async () => {
+        const { wbtc, aWbtc, users, pool } = testEnv;
+        const user = users[1];
 
-      // Mint some fake WBTC
-      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-      await wbtc.connect(user.signer).mint(amountToDeposit);
-      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+        // Mint some fake WBTC
+        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+        await wbtc.connect(user.signer).mint(amountToDeposit);
+        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
 
-      // Make sure feed and heartbeat values are what we're testing for
-      await aWbtc._setFeed(mockV3Aggregator.address);
-      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(0);
-      expect(await aWbtc.heartbeat()).to.equal(0);
+        // Make sure feed and heartbeat values are what we're testing for
+        await aWbtc._setFeed(mockV3Aggregator.address);
+        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+        await aWbtc._setHeartbeat(0);
+        expect(await aWbtc.heartbeat()).to.equal(0);
 
-      // Deposit WBTC - the aToken will call the feed before minting to check PoR
-      const balanceBefore = await aWbtc.balanceOf(user.address);
-      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-      expect(await aWbtc.balanceOf(user.address)).to.equal(amountToDeposit.add(balanceBefore));
-    });
+        // Deposit WBTC - the aToken will call the feed before minting to check PoR
+        const balanceBefore = await aWbtc.balanceOf(user.address);
+        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+        expect(await aWbtc.balanceOf(user.address)).to.equal(amountToDeposit.add(balanceBefore));
+      });
 
-    it('should mint successfully when both feed and heartbeat are set', async () => {
-      const { wbtc, aWbtc, users, pool } = testEnv;
-      const user = users[1];
+      it('should mint successfully when both feed and heartbeat are set', async () => {
+        const { wbtc, aWbtc, users, pool } = testEnv;
+        const user = users[1];
 
-      // Mint some fake WBTC
-      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-      await wbtc.connect(user.signer).mint(amountToDeposit);
-      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+        // Mint some fake WBTC
+        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+        await wbtc.connect(user.signer).mint(amountToDeposit);
+        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
 
-      // Make sure feed and heartbeat values are what we're testing for
-      await aWbtc._setFeed(mockV3Aggregator.address);
-      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
-      expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
+        // Make sure feed and heartbeat values are what we're testing for
+        await aWbtc._setFeed(mockV3Aggregator.address);
+        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+        await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
+        expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
 
-      // Deposit WBTC - the aToken will call the feed before minting to check PoR
-      const balanceBefore = await aWbtc.balanceOf(user.address);
-      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
-    });
+        // Deposit WBTC - the aToken will call the feed before minting to check PoR
+        const balanceBefore = await aWbtc.balanceOf(user.address);
+        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
+      });
 
-    it('should mint successfully when feed decimals < underlying decimals', async () => {
-      const { wbtc, aWbtc, users, pool } = testEnv;
-      const user = users[1];
+      it('should mint successfully when feed decimals < underlying decimals', async () => {
+        const { wbtc, aWbtc, users, pool } = testEnv;
+        const user = users[1];
 
-      // Mint some fake WBTC
-      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-      await wbtc.connect(user.signer).mint(amountToDeposit);
-      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+        // Mint some fake WBTC
+        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+        await wbtc.connect(user.signer).mint(amountToDeposit);
+        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
 
-      // Re-deploy aggregator with fewer decimals
-      const currentWbtcSupply = await wbtc.totalSupply();
-      mockV3Aggregator = await deployMockV3Aggregator(
-        '6',
-        currentWbtcSupply.div(exp(1, 2)).toString()
-      );
+        // Re-deploy aggregator with fewer decimals
+        const currentWbtcSupply = await wbtc.totalSupply();
+        mockV3Aggregator = await deployMockV3Aggregator(
+          '6',
+          currentWbtcSupply.div(exp(1, 2)).toString()
+        );
 
-      // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
-      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
-      expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
+        // Make sure feed and heartbeat values are set
+        await aWbtc._setFeed(mockV3Aggregator.address);
+        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+        await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
+        expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
 
-      // Deposit WBTC - the aToken will call the feed before minting to check PoR
-      const balanceBefore = await aWbtc.balanceOf(user.address);
-      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
-    });
+        // Deposit WBTC - the aToken will call the feed before minting to check PoR
+        const balanceBefore = await aWbtc.balanceOf(user.address);
+        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
+      });
 
-    it('should mint successfully when feed decimals > underlying decimals', async () => {
-      const { wbtc, aWbtc, users, pool } = testEnv;
-      const user = users[1];
+      it('should mint successfully when feed decimals > underlying decimals', async () => {
+        const { wbtc, aWbtc, users, pool } = testEnv;
+        const user = users[1];
 
-      // Mint some fake WBTC
-      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-      await wbtc.connect(user.signer).mint(amountToDeposit);
-      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+        // Mint some fake WBTC
+        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+        await wbtc.connect(user.signer).mint(amountToDeposit);
+        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
 
-      // Re-deploy aggregator with more decimals
-      const currentWbtcSupply = await wbtc.totalSupply();
-      mockV3Aggregator = await deployMockV3Aggregator(
-        '18',
-        currentWbtcSupply.mul(exp(1, 10)).toString()
-      );
+        // Re-deploy aggregator with more decimals
+        const currentWbtcSupply = await wbtc.totalSupply();
+        mockV3Aggregator = await deployMockV3Aggregator(
+          '18',
+          currentWbtcSupply.mul(exp(1, 10)).toString()
+        );
 
-      // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
-      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
-      expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
+        // Make sure feed and heartbeat values are set
+        await aWbtc._setFeed(mockV3Aggregator.address);
+        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+        await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
+        expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
 
-      // Deposit WBTC - the aToken will call the feed before minting to check PoR
-      const balanceBefore = await aWbtc.balanceOf(user.address);
-      await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
-      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
-    });
+        // Deposit WBTC - the aToken will call the feed before minting to check PoR
+        const balanceBefore = await aWbtc.balanceOf(user.address);
+        await pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0');
+        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore.add(amountToDeposit));
+      });
 
-    it('should revert if underlying supply > proof-of-reserves', async () => {
-      const { wbtc, aWbtc, users, pool } = testEnv;
-      const user = users[1];
+      it('should revert if underlying supply > proof-of-reserves', async () => {
+        const { wbtc, aWbtc, users, pool } = testEnv;
+        const user = users[1];
 
-      // Mint some fake WBTC
-      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-      await wbtc.connect(user.signer).mint(amountToDeposit);
-      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+        // Mint some fake WBTC
+        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+        await wbtc.connect(user.signer).mint(amountToDeposit);
+        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
 
-      // Re-deploy aggregator with fewer WBTC in reserves
-      const currentWbtcSupply = await wbtc.totalSupply();
-      const notEnoughReserves = currentWbtcSupply.sub('1');
-      mockV3Aggregator = await deployMockV3Aggregator('18', notEnoughReserves.toString());
+        // Re-deploy aggregator with fewer WBTC in reserves
+        const currentWbtcSupply = await wbtc.totalSupply();
+        const notEnoughReserves = currentWbtcSupply.sub('1');
+        mockV3Aggregator = await deployMockV3Aggregator('18', notEnoughReserves.toString());
 
-      // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
-      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
-      expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
+        // Make sure feed and heartbeat values are set
+        await aWbtc._setFeed(mockV3Aggregator.address);
+        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+        await aWbtc._setHeartbeat(24 * 60 * 60); // 1 day, in seconds
+        expect(await aWbtc.heartbeat()).to.equal(24 * 60 * 60);
 
-      // Deposit WBTC - the aToken will call the feed before minting to check PoR
-      const balanceBefore = await aWbtc.balanceOf(user.address);
-      await expect(
-        pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0')
-      ).to.be.revertedWith(ProtocolErrors.AT_POR_UNDERLYING_GREATER_THAN_RESERVES);
-      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore);
-    });
+        // Deposit WBTC - the aToken will call the feed before minting to check PoR
+        const balanceBefore = await aWbtc.balanceOf(user.address);
+        await expect(
+          pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0')
+        ).to.be.revertedWith(ProtocolErrors.AT_POR_UNDERLYING_GREATER_THAN_RESERVES);
+        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore);
+      });
 
-    it('should revert if the feed is not updated within the heartbeat', async () => {
-      const { wbtc, aWbtc, users, pool } = testEnv;
-      const user = users[1];
+      it('should revert if the feed is not updated within the heartbeat', async () => {
+        const { wbtc, aWbtc, users, pool } = testEnv;
+        const user = users[1];
 
-      // Mint some fake WBTC
-      const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
-      await wbtc.connect(user.signer).mint(amountToDeposit);
-      await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
+        // Mint some fake WBTC
+        const amountToDeposit = await convertToCurrencyDecimals(wbtc.address, '10');
+        await wbtc.connect(user.signer).mint(amountToDeposit);
+        await wbtc.connect(user.signer).approve(pool.address, amountToDeposit);
 
-      // Re-deploy aggregator with fewer decimals
-      mockV3Aggregator = await deployMockV3Aggregator('18', WBTC_AGG_INITIAL_ANSWER);
+        // Re-deploy aggregator with fewer decimals
+        mockV3Aggregator = await deployMockV3Aggregator('18', WBTC_AGG_INITIAL_ANSWER);
 
-      // Make sure feed and heartbeat values are set
-      await aWbtc._setFeed(mockV3Aggregator.address);
-      expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
-      const heartbeatSeconds = 24 * 60 * 60;
-      await aWbtc._setHeartbeat(heartbeatSeconds); // 1 day, in seconds
-      expect(await aWbtc.heartbeat()).to.equal(heartbeatSeconds);
+        // Make sure feed and heartbeat values are set
+        await aWbtc._setFeed(mockV3Aggregator.address);
+        expect(await aWbtc.feed()).to.equal(mockV3Aggregator.address);
+        const heartbeatSeconds = 24 * 60 * 60;
+        await aWbtc._setHeartbeat(heartbeatSeconds); // 1 day, in seconds
+        expect(await aWbtc.heartbeat()).to.equal(heartbeatSeconds);
 
-      // Heartbeat is set to 1 day, so fast-forward 2 days
-      await network.provider.send('evm_increaseTime', [2 * heartbeatSeconds]);
+        // Heartbeat is set to 1 day, so fast-forward 2 days
+        await network.provider.send('evm_increaseTime', [2 * heartbeatSeconds]);
 
-      // Deposit WBTC - the aToken will call the feed before minting to check PoR
-      const balanceBefore = await aWbtc.balanceOf(user.address);
-      await expect(
-        pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0')
-      ).to.be.revertedWith(ProtocolErrors.AT_POR_ANSWER_TOO_OLD);
-      expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore);
+        // Deposit WBTC - the aToken will call the feed before minting to check PoR
+        const balanceBefore = await aWbtc.balanceOf(user.address);
+        await expect(
+          pool.connect(user.signer).deposit(wbtc.address, amountToDeposit, user.address, '0')
+        ).to.be.revertedWith(ProtocolErrors.AT_POR_ANSWER_TOO_OLD);
+        expect(await aWbtc.balanceOf(user.address)).to.equal(balanceBefore);
+      });
+
+      describe('Set feed', () => {
+        it('should only be callable by poolAdmin', async () => {
+          const { aWbtc, users } = testEnv;
+          const regularUser = users[1];
+          await expect(
+            aWbtc.connect(regularUser.signer)._setFeed(mockV3Aggregator.address)
+          ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
+        });
+
+        it('should unset feed if called by pool admin', async () => {
+          const { aWbtc, users } = testEnv;
+          await aWbtc._setFeed(ZERO_ADDRESS);
+          expect(await aWbtc.feed()).to.equal(ZERO_ADDRESS);
+        });
+      });
+
+      describe('Set heartbeat', () => {
+        it('should only be callable by poolAdmin', async () => {
+          const { aWbtc, users } = testEnv;
+          const regularUser = users[1];
+          const oneDaySeconds = 24 * 60 * 60;
+          await expect(
+            aWbtc.connect(regularUser.signer)._setHeartbeat(oneDaySeconds)
+          ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
+        });
+
+        it('should revert if newHeartbeat > MAX_AGE', async () => {
+          const { aWbtc, users } = testEnv;
+          const regularUser = users[1];
+          const eightDaySeconds = 8 * 24 * 60 * 60;
+          await expect(aWbtc._setHeartbeat(eightDaySeconds)).to.be.revertedWith(
+            ProtocolErrors.AT_POR_HEARTBEAT_GREATER_THAN_MAX_AGE
+          );
+        });
+
+        it('should unset heartbeat if called by pool admin', async () => {
+          const { aWbtc } = testEnv;
+          await aWbtc._setHeartbeat(0);
+          expect(await aWbtc.heartbeat()).to.equal(0);
+        });
+      });
     });
   },
   { isolate: true }

--- a/test-suites/test-aave/helpers/make-suite.ts
+++ b/test-suites/test-aave/helpers/make-suite.ts
@@ -191,13 +191,8 @@ const revertHead = async () => {
   await evmRevert(buidlerevmSnapshotId);
 };
 
-export function makeSuite(
-  name: string,
-  tests: (testEnv: TestEnv) => void,
-  opts: { isolate?: boolean } = {}
-) {
-  const desc = opts?.isolate ? describe.only : describe;
-  desc(name, () => {
+export function makeSuite(name: string, tests: (testEnv: TestEnv) => void) {
+  describe(name, () => {
     before(async () => {
       await setSnapshot();
     });

--- a/test-suites/test-aave/helpers/make-suite.ts
+++ b/test-suites/test-aave/helpers/make-suite.ts
@@ -15,6 +15,7 @@ import {
   getUniswapRepayAdapter,
   getFlashLiquidationAdapter,
   getParaSwapLiquiditySwapAdapter,
+  getAPoRToken,
 } from '../../../helpers/contracts-getters';
 import { eEthereumNetwork, eNetwork, tEthereumAddress } from '../../../helpers/types';
 import { LendingPool } from '../../../types/LendingPool';
@@ -39,7 +40,7 @@ import { WETH9Mocked } from '../../../types/WETH9Mocked';
 import { WETHGateway } from '../../../types/WETHGateway';
 import { solidity } from 'ethereum-waffle';
 import { AaveConfig } from '../../../markets/aave';
-import { FlashLiquidationAdapter } from '../../../types';
+import { APoRToken, FlashLiquidationAdapter } from '../../../types';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { usingTenderly } from '../../../helpers/tenderly-utils';
 
@@ -64,6 +65,8 @@ export interface TestEnv {
   aDai: AToken;
   usdc: MintableERC20;
   aave: MintableERC20;
+  aWbtc: APoRToken;
+  wbtc: MintableERC20;
   addressesProvider: LendingPoolAddressesProvider;
   uniswapLiquiditySwapAdapter: UniswapLiquiditySwapAdapter;
   uniswapRepayAdapter: UniswapRepayAdapter;
@@ -135,6 +138,7 @@ export async function initializeMakeSuite() {
   const aDaiAddress = allTokens.find((aToken) => aToken.symbol === 'aDAI')?.tokenAddress;
 
   const aWEthAddress = allTokens.find((aToken) => aToken.symbol === 'aWETH')?.tokenAddress;
+  const aWbtcAddress = allTokens.find((aToken) => aToken.symbol === 'aWBTC')?.tokenAddress;
 
   const reservesTokens = await testEnv.helpersContract.getAllReservesTokens();
 
@@ -142,22 +146,25 @@ export async function initializeMakeSuite() {
   const usdcAddress = reservesTokens.find((token) => token.symbol === 'USDC')?.tokenAddress;
   const aaveAddress = reservesTokens.find((token) => token.symbol === 'AAVE')?.tokenAddress;
   const wethAddress = reservesTokens.find((token) => token.symbol === 'WETH')?.tokenAddress;
+  const wbtcAddress = reservesTokens.find((token) => token.symbol === 'WBTC')?.tokenAddress;
 
   if (!aDaiAddress || !aWEthAddress) {
     process.exit(1);
   }
-  if (!daiAddress || !usdcAddress || !aaveAddress || !wethAddress) {
+  if (!daiAddress || !usdcAddress || !aaveAddress || !wethAddress || !wbtcAddress) {
     process.exit(1);
   }
 
   testEnv.aDai = await getAToken(aDaiAddress);
   testEnv.aWETH = await getAToken(aWEthAddress);
+  testEnv.aWbtc = await getAPoRToken(aWbtcAddress);
 
   testEnv.dai = await getMintableERC20(daiAddress);
   testEnv.usdc = await getMintableERC20(usdcAddress);
   testEnv.aave = await getMintableERC20(aaveAddress);
   testEnv.weth = await getWETHMocked(wethAddress);
   testEnv.wethGateway = await getWETHGateway();
+  testEnv.wbtc = await getMintableERC20(wbtcAddress);
 
   testEnv.uniswapLiquiditySwapAdapter = await getUniswapLiquiditySwapAdapter();
   testEnv.uniswapRepayAdapter = await getUniswapRepayAdapter();
@@ -184,8 +191,13 @@ const revertHead = async () => {
   await evmRevert(buidlerevmSnapshotId);
 };
 
-export function makeSuite(name: string, tests: (testEnv: TestEnv) => void) {
-  describe(name, () => {
+export function makeSuite(
+  name: string,
+  tests: (testEnv: TestEnv) => void,
+  opts: { isolate?: boolean } = {}
+) {
+  const desc = opts?.isolate ? describe.only : describe;
+  desc(name, () => {
     before(async () => {
       await setSnapshot();
     });


### PR DESCRIPTION
This PR adds a new [`APoRToken`](https://github.com/smartcontractkit/aave-protocol-v2/pull/1/files#diff-5105b0265f24aee4d620aaf9c02b83e56c43dcbec70e73dfa0faa44dbb0b434aR17) that extends the existing aToken. The APoRToken utilises a Chainlink proof-of-reserves feed for custodial underlying assets such as WBTC and PAXG.